### PR TITLE
Correct the MANIFEST version + parent pom folder

### DIFF
--- a/org.eclipse.triquetrum.dependencies/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.dependencies/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum Dependencies
 Bundle-SymbolicName: org.eclipse.triquetrum.dependencies
-Bundle-Version: 0.0.1.2016011812000
+Bundle-Version: 0.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: deps/ptII/diva_11.0.0.201511291601.jar,
  deps/ptII/org.apache.commons.lang_2.6.0.v201404270220.jar,

--- a/org.eclipse.triquetrum.dependencies/pom.xml
+++ b/org.eclipse.triquetrum.dependencies/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>triquetrum</groupId>
 		<artifactId>org.eclipse.triquetrum.build</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../${pom-filename}</relativePath>
+		<relativePath>../../triquetrum</relativePath>
 	</parent>
 	<groupId>triquetrum</groupId>
 	<artifactId>org.eclipse.triquetrum.dependencies</artifactId>


### PR DESCRIPTION
The parent folder assumes that triquetrum and triquetrumDeps are sibling
folders.

Signed-off-by: Erwin De Ley erwindl0@gmail.com
